### PR TITLE
Fix _config.yml duplicate keys; add projects collection; create two sample project items; list projects on /projects/ page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,10 @@ exclude:
 - LICENSE
 - Gemfile
 - Gemfile.lock
+- vendor
+- node_modules
+- gulpfile.js
+- package.json
 
 
 # Conversion
@@ -82,6 +86,9 @@ collections:
   poetry:
     output: true
     permalink: /:collection/:title/
+  projects:
+    output: true
+    permalink: /projects/:name/
 
 # Plugins (preferred order: remote theme first)
 plugins:
@@ -120,11 +127,4 @@ defaults:
     values:
       layout: post
       share: false
-  # _exclude    
-exclude:
-         - vendor
-         - Gemfile
-         - Gemfile.lock
-         - node_modules
-         - gulpfile.js
-         - package.json      
+  # end defaults

--- a/_drafts/benchmark-game-rules-and-first-results.md
+++ b/_drafts/benchmark-game-rules-and-first-results.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Benchmark Game: Rules and First Results"
+author: Recursion Lab
+tags: [benchmark, evaluation, recursion]
+---
+
+Publish the benchmark rules, show example runs.

--- a/_drafts/delta-space-calculus-operators-of-difference-and-torsion.md
+++ b/_drafts/delta-space-calculus-operators-of-difference-and-torsion.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Δ-Space Calculus: Operators of Difference and Torsion"
+author: Recursion Lab
+tags: [calculus, delta, torsion]
+---
+
+Define the calculus, give examples.

--- a/_drafts/koriel-architecture-notes-from-the-first-draft.md
+++ b/_drafts/koriel-architecture-notes-from-the-first-draft.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Koriel Architecture: Notes from the First Draft"
+author: Recursion Lab
+tags: [koriel, cognition, architecture]
+---
+
+Outline the architecture, core operators, open problems.

--- a/_drafts/language-beyond-language-meta-affixes-and-perspectivology.md
+++ b/_drafts/language-beyond-language-meta-affixes-and-perspectivology.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Language Beyond Language: Meta-Affixes and Perspectivology"
+author: Recursion Lab
+tags: [language, semantics, recursion]
+---
+
+Show your constructed grammar pieces with examples.

--- a/_drafts/metaprincipia-autopoiesis-toward-meta-laws-of-self-production.md
+++ b/_drafts/metaprincipia-autopoiesis-toward-meta-laws-of-self-production.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "MetaPrincipia Autopoiesis: Toward Meta-Laws of Self-Production"
+author: Recursion Lab
+tags: [autopoiesis, systems, theory]
+---
+
+Post your current draft, show the diagrams, list the unresolved questions.

--- a/_drafts/translogical-calculus-a-proof-beyond-godel.md
+++ b/_drafts/translogical-calculus-a-proof-beyond-godel.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Translogical Calculus: A Proof Beyond Gödel"
+author: Recursion Lab
+tags: [logic, proof, calculus]
+---
+
+Walk through the proof sketch, why it matters.

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -6,8 +6,6 @@ permalink: /projects/
 
 ## Projects
 
-This page lists prototype ideas exploring recursive systems. Replace or expand these with your own projects as they evolve.
-
 {% assign items = site.projects | sort: 'title' %}
 {% if items and items.size > 0 %}
 <div class="project-list">
@@ -23,22 +21,20 @@ This page lists prototype ideas exploring recursive systems. Replace or expand t
 </div>
 {% endif %}
 
-### Recursive Self-Reflection Engine
-- Goal: Prototype a system that self-evaluates outputs, detects contradictions, and regenerates improved responses.
-- Sketch: Combine a language model with lightweight symbolic rules to create a feedback loop for critique → revise → verify.
-- Notes: Inspired by work on emergent recursive cognition via language-encoded symbolic systems. Add links and code when available.
+### Koriel Architecture
+Recursive cognition architecture. Whitepaper + draft specs. Prototype code in progress.
 
-### Recursive Reasoning Tools for LLMs
-- Goal: Build tools or prompt frameworks that enforce recursive reasoning (multiple passes with critique and revision).
-- Sketch: Design a reusable protocol (plan → draft → critique → revise) and measure quality gains on target tasks.
-- Notes: Start with prompt-only approaches; evolve into lightweight libraries if useful.
+### MetaPrincipia Autopoiesis
+Theory of self-producing systems with meta-laws. Notes + diagrams.
 
-### Visualization of Feedback Systems
-- Goal: Create visual/interactive models of recursive systems from biology, cognition, or social domains.
-- Sketch: Show how loops amplify, stabilize, and collapse; let users tweak parameters to see phase changes.
-- Notes: Consider small web demos or notebooks.
+### Post-Gödel Translogical Calculus
+Proof beyond incompleteness. Formal draft posted. Extensions into delta-space.
 
-### Cognitive Architecture Comparisons
-- Goal: Compare architectures (e.g., CLARION and others) to locate where explicit vs. implicit recursion plays a role.
-- Sketch: Build small simulations to highlight differences in learning and control loops.
-- Notes: Collect references (papers, Wikipedia) and plan a minimal, comparable benchmark.
+### Δ-Space Calculus
+Calculus of difference and torsion. Equations, operator library.
+
+### Benchmark Game
+Custom benchmark for recursion. Rules, scoring, open challenges.
+
+### Language Work
+Meta-affixes, metasuperpositional prepositions, perspectivology. Notes + examples.

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -8,6 +8,21 @@ permalink: /projects/
 
 This page lists prototype ideas exploring recursive systems. Replace or expand these with your own projects as they evolve.
 
+{% assign items = site.projects | sort: 'title' %}
+{% if items and items.size > 0 %}
+<div class="project-list">
+	<ul>
+	{% for item in items %}
+		<li>
+			<a href="{{ item.url }}">{{ item.title }}</a>
+			{% if item.summary %}<div class="project-summary">{{ item.summary }}</div>{% endif %}
+		</li>
+	{% endfor %}
+	</ul>
+	<hr/>
+</div>
+{% endif %}
+
 ### Recursive Self-Reflection Engine
 - Goal: Prototype a system that self-evaluates outputs, detects contradictions, and regenerates improved responses.
 - Sketch: Combine a language model with lightweight symbolic rules to create a feedback loop for critique → revise → verify.

--- a/_projects/recursive-reasoning-tools-for-llms.md
+++ b/_projects/recursive-reasoning-tools-for-llms.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Recursive Reasoning Tools for LLMs
+summary: Tools and protocols that enforce recursive reasoning via plan → draft → critique → revise loops.
+status: concept
+permalink: /projects/recursive-reasoning-tools-for-llms/
+---
+
+Goal: Build tools or prompt frameworks that enforce recursive reasoning (multiple passes with critique and revision).
+
+Sketch: Design a reusable protocol (plan → draft → critique → revise) and measure quality gains on target tasks.
+
+Notes: Start with prompt-only approaches; evolve into lightweight libraries if useful.

--- a/_projects/recursive-self-reflection-engine.md
+++ b/_projects/recursive-self-reflection-engine.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Recursive Self-Reflection Engine
+summary: Prototype that self-evaluates outputs, detects contradictions, and regenerates improved responses.
+status: concept
+permalink: /projects/recursive-self-reflection-engine/
+---
+
+Goal: Prototype a system that self-evaluates outputs, detects contradictions, and regenerates improved responses.
+
+Sketch: Combine a language model with lightweight symbolic rules to create a feedback loop for critique → revise → verify.
+
+Notes: Inspired by work on emergent recursive cognition via language-encoded symbolic systems. Add links and code when available.

--- a/about.md
+++ b/about.md
@@ -6,19 +6,17 @@ permalink: /about/
 
 ## About
 
-Recursion Lab studies the interplay of recursion, cognition, and systems. We publish public notes and working prototypes that test ideas about feedback, self‑reference, and emergent behavior.
+Recursion Lab studies recursion as a generative mechanism in cognition and systems.
 
-We believe recursion is a core mechanism — in learning, in feedback, and in self‑reference. Through notes, experiments, and open-source prototypes we explore:
+This is the public notebook of ongoing architectures, formalisms, and prototypes.
 
-- How recursive architectures enable emergent cognition
-- How biological, computational, and social systems stabilize via feedback loops
-- What happens when recursion is applied to meaning, memory, and identity
+### Current lines of work
 
-This site is a research‑and‑prototype space. Browse the Blog for ongoing notes, and Projects for experiments you can try. Replace this paragraph with your contact or newsletter link when ready.
----
-title: About
-layout: page
----
+- Koriel Architecture — a recursive cognition engine
+- MetaPrincipia Autopoiesis — meta-laws for self-producing systems
+- Translogical Calculus (post-Gödel) — proof and extensions
+- Δ-Space Calculus — formalism for differences and torsion fields
+- Benchmark Game — live testbed for recursive intelligence
+- Language frameworks — meta-affixes, metasuperpositional prepositions, perspectivology
 
-## About
-Short description here.
+This site holds notes, working prototypes, and proofs in progress.


### PR DESCRIPTION
## Summary by Sourcery

Add and configure a new 'projects' collection by cleaning up '_config.yml', implement a listing page at '/projects/', and include two example project items

New Features:
- Add 'projects' collection with output and permalink settings
- Create a '/projects/' page that dynamically lists all project items
- Add two sample project entries in the '_projects' directory

Bug Fixes:
- Remove duplicate 'exclude' keys and consolidate excluded paths in '_config.yml'